### PR TITLE
🔧 Corrigido erro no retorno de notícias por categoria e pesquisa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 
 ## database
 /database/postgres-data
+
+## ambiente depuração
+/developenviroment/**

--- a/src/main/java/com/techdecode/blog/dto/CategoryDto.java
+++ b/src/main/java/com/techdecode/blog/dto/CategoryDto.java
@@ -1,13 +1,11 @@
 package com.techdecode.blog.dto;
 
-import com.techdecode.blog.models.PostModel;
-
 import java.util.List;
 import java.util.UUID;
 
 public record CategoryDto(
         UUID id,
         String title,
-        List<PostModel> postModels
+        List<PostSmallDto> postModels
 ) {
 }

--- a/src/main/java/com/techdecode/blog/dto/PostSmallDto.java
+++ b/src/main/java/com/techdecode/blog/dto/PostSmallDto.java
@@ -1,0 +1,11 @@
+package com.techdecode.blog.dto;
+
+import java.util.UUID;
+
+public record PostSmallDto(
+        UUID id,
+        String title,
+        String bannerUrl,
+        String date_at
+) {
+}

--- a/src/main/java/com/techdecode/blog/models/PostModel.java
+++ b/src/main/java/com/techdecode/blog/models/PostModel.java
@@ -16,6 +16,7 @@ public class PostModel implements Serializable {
     private String title;
     private String bannerUrl;
     @Lob
+    @Basic(fetch = FetchType.EAGER)
     private String description;
     private String font;
     private String date_at;

--- a/src/main/java/com/techdecode/blog/service/PostService.java
+++ b/src/main/java/com/techdecode/blog/service/PostService.java
@@ -2,6 +2,7 @@ package com.techdecode.blog.service;
 
 import com.techdecode.blog.dto.CategoryDto;
 import com.techdecode.blog.dto.PostDto;
+import com.techdecode.blog.dto.PostSmallDto;
 import com.techdecode.blog.models.CategoryModel;
 import com.techdecode.blog.models.PostModel;
 import com.techdecode.blog.models.exceptions.ConflictException;
@@ -11,6 +12,7 @@ import com.techdecode.blog.repository.PostRepository;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -83,7 +85,9 @@ public class PostService {
         );
     }
 
+    @Transactional
     public CategoryDto findPostByCategory(UUID id) {
+
         Optional<CategoryModel> categoryModelOptional = this.categoryRepository.findById(id);
 
         if (categoryModelOptional.isEmpty()) {
@@ -92,9 +96,14 @@ public class PostService {
 
         CategoryModel categoryModel = categoryModelOptional.get();
 
-        return new CategoryDto(categoryModel.getId(), categoryModel.getTitle(), categoryModel.getPostModels());
+        List<PostSmallDto> postSmallDtos = categoryModel.getPostModels().stream()
+                .map(postModel -> new PostSmallDto(postModel.getId(), postModel.getTitle(), postModel.getBannerUrl(), postModel.getDate_at()))
+                .toList();
+
+        return new CategoryDto(categoryModel.getId(), categoryModel.getTitle(), postSmallDtos);
     }
 
+    @Transactional
     public List<PostDto> searchPost(String search) {
         List<PostModel> postModels = this.postRepository.findByTitleContaining(search);
         return postModels.stream()


### PR DESCRIPTION
## 🚀 O que foi feito:

- Resolvido o problema de retorno de notícias filtradas por categoria, causado por campos @Lob não carregados corretamente.
- Resolvido o problema de retorno de noticias por pesquisas com a anotação @Transactional
- Ajustada a lógica de serialização para evitar erros com grandes textos no campo description.